### PR TITLE
Update pre-commit settings for modern Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         tox-envs: [docs, doctests, linkcheck, lint]
     defaults:
-      run: 
+      run:
         shell: bash -el {0}
     steps:
     - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10.12, 3.11.3]
+        python-version: [3.11, 3.12, 3.13]
     defaults:
       run:
         shell: bash -el {0}
@@ -147,7 +147,7 @@ jobs:
           channels: conda-forge
           auto-update-conda: false
           auto-activate-base: true
-          python-version: 3.11
+          python-version: 3.13
       - name: Deploy Package To conda-forge
         run: |
           conda install conda-build conda-verify

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,10 @@ repos:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 25.1.0
   hooks:
   - id: black
-    language_version: python3
+    language_version: python3.11
 
 - repo: https://github.com/asottile/blacken-docs
   rev: 1.13.0
@@ -55,7 +55,7 @@ repos:
   - id: codespell
 
 - repo: https://github.com/commitizen-tools/commitizen
-  rev: 3.2.2 # automatically updated by Commitizen
+  rev: v3.2.2 # automatically updated by Commitizen
   hooks:
   - id: commitizen
     additional_dependencies: [commitizen==2.21.0]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,7 @@
   description: Lint Python test descriptions and test code with schema from a test template.
   entry: ats-linter
   language: python
+  language_version: python3.11
   types: [python]
   include: ^**/test_.*\.py$
   args: []

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,9 +23,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python >=3.11
   run:
-    - python >=3.8
+    - python >=3.11
 
 test:
   imports:

--- a/conda_envs/dev_env.yml
+++ b/conda_envs/dev_env.yml
@@ -2,7 +2,7 @@ name: ats-linter-dev
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8
+  - python >= 3.11
   - pytest
   - pytest-mock
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Automated test schema linter"
 authors = [
     {name = "Aydin Abdi", email = "ayd.abd@gmail.com"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 readme = "README.rst"
 license = {file = "LICENSE.txt"}
 classifiers = [
@@ -28,11 +28,9 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",
     "Topic :: Utilities",
@@ -56,7 +54,7 @@ ats-linter = "ats_linter.cli:run"
 
 [tool.black]
 line-length = 88
-target-version = ["py38", "py38", "py39"]
+target-version = ["py311", "py312", "py313"]
 include = '\.pyi?$'
 
 exclude = '''

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3
-envlist = py3{8,9,10,11}
+envlist = py3{11,12,13}
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -18,7 +18,7 @@ conda_channels =
 setenv =
     TOXINIDIR = {toxinidir}
     PIP_DISABLE_PIP_VERSION_CHECK = 1
-    py3{8,9,10,11}: COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
+    py3{11,12,13}: COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 passenv =
     HOME
     SETUPTOOLS_*


### PR DESCRIPTION
## Summary
- update pre-commit to run black with Python 3.11
- correct commitizen hook revision
- bump supported Python versions to 3.11+
- adjust tox and conda files for new Python versions
- update CI matrix to Python 3.11–3.13

## Testing
- `pre-commit run --files .pre-commit-config.yaml .pre-commit-hooks.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829ce072c483288bb9a719a5dfd780